### PR TITLE
Fix link for R installation process

### DIFF
--- a/part-tools/02-setting-up-computer.qmd
+++ b/part-tools/02-setting-up-computer.qmd
@@ -42,14 +42,14 @@ If you have trouble with these instructions or encounter an error, post on the c
 
 ### {{< fa brands windows >}} Windows
 
-1. Get the R installer from CRAN: https://cran.rstudio.com/bin/windows/base/
+1. Get the R installer from CRAN: <https://cran.rstudio.com/bin/windows/base/>
 
-2. Install the Rtools4 package that matches the R version you installed: https://cran.rstudio.com/bin/windows/Rtools/    
+2. Install the Rtools4 package that matches the R version you installed: <https://cran.rstudio.com/bin/windows/Rtools/>    
 For example, if you installed R 4.4.3, you should download RTools 4.4. If you installed R 4.0.1, you should install RTools 4.0. 
 
 ### {{< fa brands apple >}} Mac
 
-1. Get the R installer from CRAN: https://cran.rstudio.com/bin/macosx/
+1. Get the R installer from CRAN: <https://cran.rstudio.com/bin/macosx/>
 
 2. Install XCode - a set of developer tools - so that you can install R packages more easily. There are two ways to do this:
 
@@ -58,10 +58,12 @@ For example, if you installed R 4.4.3, you should download RTools 4.4. If you in
   
 I personally suggest option b, because Homebrew is used for a lot of different software-development related things, and having it will make life easier later. 
   
-::: {.callout-info collapse=true}
-#### Installing Homebrew + XCode {-}
+---
+
+##### Installing Homebrew + XCode {-}
 ```
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+/bin/bash -c "$(curl -fsSL 
+https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
 ```
@@ -69,11 +71,9 @@ brew install mas # Search the apple store
 mas search xcode # find xcode
 mas install 497799835 # install the program by ID
 ```
-:::
   
 
-
-### {{< fa brands linux >}} Linux
+#### {{< fa brands linux >}} Linux  {.unnumbered}
 
 If you're using a distribution like Debian, Fedora, RedHat, or Ubuntu, or a distribution derived from one of these distributions, follow the instructions below.
 
@@ -83,25 +83,38 @@ If you're using Arch or another distribution that isn't derived from something l
 
 ---
 
-#### Installation Instructions {-}
+##### Installation Instructions {-}
 
-1. Get the R installer from CRAN: https://cran.rstudio.com/bin/linux/ -  pick your distribution, and follow the distribution-specific instructions from there. 
+1. Get the R installer from CRAN: <https://cran.rstudio.com/bin/linux/> -  pick your distribution, and follow the distribution-specific instructions from there. 
 
 
 You could install R using your package manager, but often this version is out of date. The instructions for each version will get you a more up-to-date version that will be easier to work with.
 
 :::
 
+::::
 
 2.  Download and install the latest version of [python 3](https://www.python.org/downloads/)
 
-    -   {{< fa brands windows >}} Windows: **check the box that asks if you want to add Python to the system path.**
-        This will save you a *lot* of time and frustration. If you didn't do this, you can follow [these instructions](https://www.geeksforgeeks.org/how-to-add-python-to-windows-path/) to fix the issue (you'll need to restart your machine).
+:::: setup
 
-    -   If you're interested in python, you should install Jupyter using the instructions [here](https://jupyter.org/install) (I would just do `pip3 install jupyterlab`)\
-        We will not use jupyter much in this book - I prefer quarto - but the python community has decided to distribute code primarily in jupyter notebooks, so having it on your machine may be useful so that you can run other people's code.
+#### Extra Instructions to Setup Python on  {{< fa brands windows >}} Windows {-}
 
-    -   [Additional instructions for installing Python 3](https://www.py4e.com/lessons/install) from Python for Everybody if you have trouble.
+**check the box that asks if you want to add Python to the system path.**    
+This will save you a *lot* of time and frustration. 
+If you didn't do this, you can follow [these instructions](https://www.geeksforgeeks.org/how-to-add-python-to-windows-path/) to fix the issue (you'll need to restart your machine).
+
+::::
+
+:::: learnmore
+
+-   If you're interested in python, you should install Jupyter using the instructions [here](https://jupyter.org/install) (I would just do `pip3 install jupyterlab`)\
+    We will not use jupyter much in this book - I prefer quarto - but the python community has decided to distribute code primarily in jupyter notebooks, so having it on your machine may be useful so that you can run other people's code.
+
+-   [Additional instructions for installing Python 3](https://www.py4e.com/lessons/install) from Python for Everybody if you have trouble.
+
+::::
+
 
 3.  Download and install the [latest version of RStudio](https://posit.co/download/rstudio-desktop/#download) for your operating system.
     RStudio is a integrated development environment (IDE) for R, created by Posit.
@@ -119,9 +132,13 @@ If you want to be safe, go ahead and complete these steps as well.
     
     We will configure git later, in @sec-git. For now, let's just get it installed. 
 
-6.  Install LaTeX, rmarkdown, and quarto:
+6.  Install LaTeX, rmarkdown, and quarto
 
-    -   Launch R, and type the following commands into the console:
+:::: setup
+
+#### Set Up Document Processing Software {.unnumbered}
+
+-   Launch R, and type the following commands into the console:
 
     ```{r tinytex-install, eval = F}
     install.packages(c("tinytex", "knitr", "rmarkdown", "quarto"))
@@ -129,14 +146,17 @@ If you want to be safe, go ahead and complete these steps as well.
     install_tinytex()
     ```
     
-    If you have an existing installation of LaTeX, using tinytex or another installer, I highly recommend that you uninstall LaTeX before re-installing the most recent version. 
-    
-    - Configure RStudio to use the tinytex installation of LaTeX: 
-        - Go to Tools -> Global Options -> Sweave    
-        ![A view of the RStudio Sweave configuration pane, with settings for PDF generation and LaTeX editing as recommended for this textbook's instructions.](../images/tools/Rstudio-sweave-config.png){fig-alt="The RStudio configuration pane for Sweave. The PDF generation options are as follows: Weave Rnw files using `knitr`, Typeset LaTeX into PDF using `XeLaTeX` (for font compatibility and modern rendering). The LaTeX editing and compilation options are a set of checkboxes; the two checked options are use tinytex when compiling .tex files, and Clean auxiliary output after compile. The PDF preview options can be set as you desire and are highly operating-system dependent."}
+If you have an existing installation of LaTeX, using tinytex or another installer, I highly recommend that you uninstall LaTeX before re-installing the most recent version. 
 
-::: callout-tip
-### Your turn {.unnumbered}
+- Configure RStudio to use the tinytex installation of LaTeX: 
+    - Go to Tools -> Global Options -> Sweave    
+    ![A view of the RStudio Sweave configuration pane, with settings for PDF generation and LaTeX editing as recommended for this textbook's instructions.](../images/tools/Rstudio-sweave-config.png){fig-alt="The RStudio configuration pane for Sweave. The PDF generation options are as follows: Weave Rnw files using `knitr`, Typeset LaTeX into PDF using `XeLaTeX` (for font compatibility and modern rendering). The LaTeX editing and compilation options are a set of checkboxes; the two checked options are use tinytex when compiling .tex files, and Clean auxiliary output after compile. The PDF preview options can be set as you desire and are highly operating-system dependent."}
+
+::::
+
+
+::: example
+### Your turn: Exploring (and configuring) RStudio {.unnumbered}
 
 Open RStudio on your computer and explore a bit.
 


### PR DESCRIPTION
In the installation process section, a few links were not directly clickable. I updated the markdown so that the links are now active and can be accessed with a single click.